### PR TITLE
fix: make it so Xcode checks aren't as strict

### DIFF
--- a/Harbor/Systems/XCLIUtils.swift
+++ b/Harbor/Systems/XCLIUtils.swift
@@ -36,9 +36,6 @@ final class XCLIUtils {
             return
         }
         task.waitUntilExit()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        if let output = String(data: data, encoding: .utf8) {
-            installed = output.contains("version: 15.")
-        }
+        installed = task.terminationStatus == 0
     }
 }


### PR DESCRIPTION
(because you literally cannot install Harbor if it doesn't pass anyway)